### PR TITLE
Simdjson and level loading implementation

### DIFF
--- a/src/game/level.cpp
+++ b/src/game/level.cpp
@@ -2,14 +2,210 @@
 
 #include <engine/input/asset.h>
 
-void Level::load_json(std::vector<std::shared_ptr<Entity>> *entities, const std::string path) {
-  char real_path[256];
 
-  asset_find(path.c_str(), real_path);
+void Level::load_json(std::vector<std::shared_ptr<Entity>>* entities, const std::string path) {
+	char real_path[256];
 
-  simdjson::padded_string json = simdjson::padded_string::load(real_path);
+	asset_find(path.c_str(), real_path);
 
-  this->json_data = this->json_parser.iterate(json);
+	simdjson::padded_string json = simdjson::padded_string::load(real_path);
+
+	this->json_data = this->json_parser.iterate(json);
+
+	simdjson::ondemand::object json_data_obj(this->json_data.get_object());
+	u32 json_data_size = json_data_obj.count_fields();
+	std::string layer_id;
+
+	for (u32 i = 0; i < (json_data_size - 14); i++) {
+		if (i == 0)
+			layer_id = "/layers";
+		else
+			layer_id = "/layers" + std::to_string(i);
+
+		simdjson::ondemand::array layers = this->json_data.at_pointer(layer_id).get_array();
+
+		simdjson::ondemand::array background_array = layers.at_pointer("/0/chunks").get_array();
+
+		u32 bg_array_size = background_array.count_elements();
+
+		for (u32 i = 0; i < bg_array_size; i++) {
+
+			std::string json_pointer = layer_id + "/0/chunks/" + std::to_string(i);
+
+			simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
+
+			double x = obj["x"];
+			double y = obj["y"];
+
+			std::vector<u32> values;
+
+			simdjson::ondemand::array arr((obj["data"].get_array()));
+
+			for (double value : arr)
+				values.push_back(value);
+
+
+			this->background_content.emplace_back(x, y, std::move(values));
+		}
+
+		simdjson::ondemand::array objects_array = this->json_data.at_pointer(layer_id + "/1/objects").get_array();
+		u32 obj_array_size = objects_array.count_elements();
+
+		for (u32 i = 0; i < obj_array_size; i++) {
+
+			std::string json_pointer = layer_id + "/1/objects/" + std::to_string(i);
+
+			simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
+
+			double x = obj["x"];
+			double y = obj["y"];
+			double width = obj["width"];
+			double height = obj["height"];
+			double tileset_id = obj["id"];
+
+			simdjson::ondemand::array property_array = this->json_data.at_pointer(json_pointer + "/properties").get_array();
+			u32 prop_array_size = property_array.count_elements();
+			std::string_view script = "0";
+
+			for (u32 i = 0; i < prop_array_size; i++) {
+
+				simdjson::ondemand::object obj(property_array.at_pointer("/" + std::to_string(i)).get_object());
+
+				script = obj["value"];
+			}
+
+			objects_content.emplace_back(x, y, width, height, tileset_id, script);
+		}
+
+		simdjson::ondemand::array collisions_array = this->json_data.at_pointer(layer_id + "/2/chunks").get_array();
+
+		u32 co_array_size = collisions_array.count_elements();
+
+		for (u32 i = 0; i < co_array_size; i++) {
+
+			std::string json_pointer = layer_id + "/2/chunks/" + std::to_string(i);
+
+			simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
+
+			double x = obj["x"];
+			double y = obj["y"];
+
+			std::vector<double> values;
+
+			simdjson::ondemand::array arr((obj["data"].get_array()));
+
+			for (double value : arr)
+				values.push_back(value);
+
+			collisions_content.emplace_back(x, y, std::move(values));
+		}
+	}
+
+	simdjson::ondemand::array tilesets = this->json_data["tilesets"];
+	u32 tilesets_size = tilesets.count_elements();
+
+
+	for (int i = 0; i < tilesets_size; i++) {
+
+		std::string json_pointer = "/tilesets/" + std::to_string(i);
+		std::string_view tileset_id;
+
+		simdjson::ondemand::object obj(json_data.at_pointer(json_pointer).get_object());
+		std::string_view tileset = obj["source"];
+
+
+
+		tileset_id_jsons.emplace_back(tileset);
+	}
+
+	for (u32 i = 0; i < tileset_id_jsons.size(); i++) {
+		std::cout << tileset_id_jsons[i] << std::endl;
+	}
+
+
+	for (u32 i = 0; i < tileset_id_jsons.size(); i++) {
+		std::string tileset = tileset_id_jsons.at(i);
+		simdjson::padded_string id_json = simdjson::padded_string::load(tileset);
+
+		this->id_json_data = json_parser.iterate(id_json);
+
+		simdjson::ondemand::object id_obj = id_json_data;
+		std::string_view tileset_id = id_obj["image"];
+
+		tileset_id_list.emplace_back(tileset_id);
+	}
 }
 
-void Level::update() {}
+void Level::update() {
+	for (const auto& arr : background_content) {
+		u32 x_counter = 0;
+		u32 y_counter = 0;
+
+		u32 x = arr.x;
+		u32 y = arr.y;
+
+		for (u32 i = 0; i < arr.background_data.size(); i++) {
+
+			u32 data = arr.background_data.at(i);
+
+			if (data > 0) {
+				std::string id = tileset_id_list.at(data - 1);
+				std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
+				ent->set_ent_class(EntClass::BACKGROUND);
+				ent->set_texture_path(id);
+				ent->set_pos(vector_make3(x * 0.1 + x_counter * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
+				ent->set_active(true);
+			}
+			x_counter++;
+
+			if ((i + 1) % 16 == 0) {
+				x_counter = 0;
+				y_counter++;
+			}
+			else if ((i + 1) % 256 == 0) {
+				y_counter = 0;
+			}
+		}
+	}
+
+
+	for (const auto& arr : objects_content) {
+		u32 x = arr.x;
+		u32 y = arr.y;
+		u32 height = arr.height;
+		u32 width = arr.width;
+		u32 id = arr.tileset_id;
+		std::string script = arr.script;
+
+	}
+
+	for (const auto& arr : collisions_content) {
+		u32 x_counter = 0;
+		u32 y_counter = 0;
+
+		for (u32 i = 0; i < arr.collisions_data.size(); i++) {
+			u32 x = arr.x;
+			u32 y = arr.y;
+			u32 data = arr.collisions_data.at(i);
+
+			if (data > 0) {
+				std::string id = tileset_id_list.at(data - 1);
+				std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
+				ent->set_ent_class(EntClass::BACKGROUND);
+				ent->set_texture_path(id);
+				ent->set_pos(vector_make3(x * 0.1 + x_counter * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
+				ent->set_active(true);
+			}
+
+			x_counter++;
+
+			if ((i + 1) % 16 == 0) {
+				x_counter = 0;
+				y_counter++;
+			}
+			else if ((i + 1) % 256 == 0) {
+				y_counter = 0;
+			}
+		}
+	}
+}

--- a/src/game/level.cpp
+++ b/src/game/level.cpp
@@ -1,194 +1,164 @@
 #include "level.h"
-
 #include <engine/input/asset.h>
 
-void Level::load_json(std::vector<std::shared_ptr<Entity>> *entities, const std::string path) {
-  char real_path[256];
 
-  asset_find(path.c_str(), real_path);
+void Level::load_json(std::vector<std::shared_ptr<Entity>>* entities, const std::string path) {
+	char real_path[256];
 
-  simdjson::padded_string json = simdjson::padded_string::load(real_path);
+	asset_find(path.c_str(), real_path);
 
-  this->json_data = this->json_parser.iterate(json);
+	simdjson::padded_string json = simdjson::padded_string::load(real_path);
 
-  simdjson::ondemand::object json_data_obj(this->json_data.get_object());
-  u32 json_data_size = json_data_obj.count_fields();
-  std::string layer_id;
+	this->json_data = this->json_parser.iterate(json);
 
-  for (u32 i = 0; i < (json_data_size - 14); i++) {
-    if (i == 0)
-      layer_id = "/layers";
-    else
-      layer_id = "/layers" + std::to_string(i);
+	simdjson::ondemand::object json_data_obj(this->json_data.get_object());
+	std::string layer_id;
 
-    simdjson::ondemand::array layers = this->json_data.at_pointer(layer_id).get_array();
+	for (u32 i = 0; i < (json_data_obj.count_fields() - 14); i++) {
+		if (i == 0)
+			layer_id = "/layers";
+		else
+			layer_id = "/layers" + std::to_string(i);
 
-    simdjson::ondemand::array background_array = layers.at_pointer("/0/chunks").get_array();
+		simdjson::ondemand::array layers = this->json_data.at_pointer(layer_id).get_array();
+		simdjson::ondemand::array background_array = layers.at_pointer("/0/chunks").get_array();
 
-    u32 bg_array_size = background_array.count_elements();
+		for (u32 i = 0; i < background_array.count_elements(); i++) {
 
-    for (u32 i = 0; i < bg_array_size; i++) {
-      std::string json_pointer = layer_id + "/0/chunks/" + std::to_string(i);
+			simdjson::ondemand::object obj(this->json_data.at_pointer(layer_id + "/0/chunks/" + std::to_string(i)).get_object());
 
-      simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
+			std::vector<u32> values;
 
-      f64 x = obj["x"];
-      f64 y = obj["y"];
+			simdjson::ondemand::array arr((obj["data"].get_array()));
 
-      std::vector<u32> values;
+			for (i64 value : arr)
+				values.push_back(value);
 
-      simdjson::ondemand::array arr((obj["data"].get_array()));
+			this->background.emplace_back(obj["x"], obj["y"], std::move(values));
+		}
 
-      for (f64 value : arr)
-        values.push_back(value);
+		simdjson::ondemand::array objects_array = this->json_data.at_pointer(layer_id + "/1/objects").get_array();
 
-      this->background_content.emplace_back(x, y, std::move(values));
-    }
+		for (u32 i = 0; i < objects_array.count_elements(); i++) {
 
-    simdjson::ondemand::array objects_array = this->json_data.at_pointer(layer_id + "/1/objects").get_array();
-    u32 obj_array_size                      = objects_array.count_elements();
+			simdjson::ondemand::object obj(this->json_data.at_pointer(layer_id + "/1/objects/" + std::to_string(i)).get_object());
 
-    for (u32 i = 0; i < obj_array_size; i++) {
-      std::string json_pointer = layer_id + "/1/objects/" + std::to_string(i);
+			simdjson::ondemand::array property_array =
+				this->json_data.at_pointer(layer_id + "/1/objects/" + std::to_string(i) + "/properties").get_array();
+			std::string_view script = "0";
 
-      simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
+			for (u32 i = 0; i < property_array.count_elements(); i++) {
 
-      f64 x          = obj["x"];
-      f64 y          = obj["y"];
-      f64 width      = obj["width"];
-      f64 height     = obj["height"];
-      f64 tileset_id = obj["id"];
+				simdjson::ondemand::object obj(property_array.at_pointer("/" + std::to_string(i)).get_object());
 
-      simdjson::ondemand::array property_array = this->json_data.at_pointer(json_pointer + "/properties").get_array();
-      u32 prop_array_size                      = property_array.count_elements();
-      std::string script                       = "return";
+				script = obj["value"];
+			}
+			objects.emplace_back(obj["x"], obj["y"], obj["width"], obj["height"], obj["id"], script);
+		}
 
-      for (u32 i = 0; i < prop_array_size; i++) {
-        simdjson::ondemand::object obj(property_array.at_pointer("/" + std::to_string(i)).get_object());
+		simdjson::ondemand::array collisions_array = this->json_data.at_pointer(layer_id + "/2/chunks").get_array();
 
-        script = std::string_view(obj["value"]);
-      }
+		for (u32 i = 0; i < collisions_array.count_elements(); i++) {
 
-      objects_content.emplace_back(x, y, width, height, tileset_id, script);
-    }
+			simdjson::ondemand::object obj(this->json_data.at_pointer(layer_id + "/2/chunks/" + std::to_string(i)).get_object());
 
-    simdjson::ondemand::array collisions_array = this->json_data.at_pointer(layer_id + "/2/chunks").get_array();
+			std::vector<i64> values;
 
-    u32 co_array_size = collisions_array.count_elements();
+			simdjson::ondemand::array arr((obj["data"].get_array()));
 
-    for (u32 i = 0; i < co_array_size; i++) {
-      std::string json_pointer = layer_id + "/2/chunks/" + std::to_string(i);
+			for (i64 value : arr) {
+				values.push_back(value);
+			}
+			collisions.emplace_back(obj["x"], obj["y"], std::move(values));
+		}
+	}
 
-      simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
+	simdjson::ondemand::array tilesets = this->json_data["tilesets"];
 
-      i64 x = obj["x"];
-      i64 y = obj["y"];
+	for (u32 i = 0; i < tilesets.count_elements(); i++) {
 
-      std::vector<u64> values;
+		simdjson::ondemand::object obj(json_data.at_pointer("/tilesets/" + std::to_string(i)).get_object());
 
-      simdjson::ondemand::array arr((obj["data"].get_array()));
+		tileset_id_json.emplace_back(std::string_view(obj["source"]));
+	}
 
-      for (u64 value : arr)
-        values.push_back(value);
+	for (u32 i = 0; i < tileset_id_json.size(); i++) {
+		std::string tileset = tileset_id_json.at(i);
+		simdjson::padded_string id_json = simdjson::padded_string::load(tileset);
 
-      collisions_content.emplace_back(x, y, std::move(values));
-    }
-  }
+		this->id_json_data = json_parser.iterate(id_json);
 
-  simdjson::ondemand::array tilesets = this->json_data["tilesets"];
-  u32 tilesets_size                  = tilesets.count_elements();
+		simdjson::ondemand::object id_obj = id_json_data;
 
-  for (int i = 0; i < tilesets_size; i++) {
-    std::string json_pointer = "/tilesets/" + std::to_string(i);
-    std::string_view tileset_id;
+		tileset_id_list.emplace_back(id_obj["image"]);
+	}
+}
 
-    simdjson::ondemand::object obj(json_data.at_pointer(json_pointer).get_object());
-    std::string_view tileset = obj["source"];
+void Level::init() {
+	for (const Background arr : background) {
+		u32 y_counter = 0;
 
-    tileset_id_jsons.emplace_back(tileset);
-  }
+		u32 x = arr.x;
+		u32 y = arr.y;
 
-  for (u32 i = 0; i < tileset_id_jsons.size(); i++)
-    std::cout << tileset_id_jsons[i] << std::endl;
+		for (u32 i = 0; i < arr.background_data.size(); i++) {
+			u32 data = arr.background_data.at(i);
 
-  for (u32 i = 0; i < tileset_id_jsons.size(); i++) {
-    std::string tileset             = tileset_id_jsons.at(i);
-    simdjson::padded_string id_json = simdjson::padded_string::load(tileset);
+			if (data > 0) {
+				std::string id = tileset_id_list.at(data - 1);
+				std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
+				ent->set_ent_class(EntClass::BACKGROUND);
+				ent->set_texture_path(id);
+				ent->set_pos(vector_make3(x * 0.1 + (i % 16) * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
+				ent->set_active(true);
+			}
 
-    this->id_json_data = json_parser.iterate(id_json);
+			if ((i + 1) % 16 == 0) {
+				y_counter++;
+			}
 
-    simdjson::ondemand::object id_obj = id_json_data;
-    std::string_view tileset_id       = id_obj["image"];
+			if ((i + 1) % 256 == 0) {
+				y_counter = 0;
+			}
+		}
+	}
 
-    tileset_id_list.emplace_back(tileset_id);
-  }
+	for (const Object arr : objects) {
+		u32 x = arr.x;
+		u32 y = arr.y;
+		u32 height = arr.height;
+		u32 width = arr.width;
+		u32 id = arr.tileset_id;
+		std::string script = arr.script;
+	}
+
+	for (const Collision arr : collisions) {
+		u32 y_counter = 0;
+
+		for (u32 i = 0; i < arr.collisions_data.size(); i++) {
+			u32 x = arr.x;
+			u32 y = arr.y;
+			u32 data = arr.collisions_data.at(i);
+
+			if (data > 0) {
+				std::string id = tileset_id_list.at(data - 1);
+				std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
+				ent->set_ent_class(EntClass::BACKGROUND);
+				ent->set_texture_path(id);
+				ent->set_pos(vector_make3(x * 0.1 + ((i + 1) % 16) * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
+				ent->set_active(true);
+			}
+
+			if ((i + 1) % 16 == 0) {
+				y_counter++;
+			}
+
+			if ((i + 1) % 256 == 0) {
+				y_counter = 0;
+			}
+		}
+	}
 }
 
 void Level::update() {
-  for (const auto &arr : background_content) {
-    u32 x_counter = 0;
-    u32 y_counter = 0;
-
-    u32 x = arr.x;
-    u32 y = arr.y;
-
-    for (u32 i = 0; i < arr.background_data.size(); i++) {
-      u32 data = arr.background_data.at(i);
-
-      if (data > 0) {
-        std::string id              = tileset_id_list.at(data - 1);
-        std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
-        ent->set_ent_class(EntClass::BACKGROUND);
-        ent->set_texture_path(id);
-        ent->set_pos(vector_make3(x * 0.1 + x_counter * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
-        ent->set_active(true);
-      }
-      x_counter++;
-
-      if ((i + 1) % 16 == 0) {
-        x_counter = 0;
-        y_counter++;
-      } else if ((i + 1) % 256 == 0) {
-        y_counter = 0;
-      }
-    }
-  }
-
-  for (const auto &arr : objects_content) {
-    u32 x              = arr.x;
-    u32 y              = arr.y;
-    u32 height         = arr.height;
-    u32 width          = arr.width;
-    u32 id             = arr.tileset_id;
-    std::string script = arr.script;
-  }
-
-  for (const auto &arr : collisions_content) {
-    u32 x_counter = 0;
-    u32 y_counter = 0;
-
-    for (u32 i = 0; i < arr.collisions_data.size(); i++) {
-      u32 x    = arr.x;
-      u32 y    = arr.y;
-      u32 data = arr.collisions_data.at(i);
-
-      if (data > 0) {
-        std::string id              = tileset_id_list.at(data - 1);
-        std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
-        ent->set_ent_class(EntClass::BACKGROUND);
-        ent->set_texture_path(id);
-        ent->set_pos(vector_make3(x * 0.1 + x_counter * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
-        ent->set_active(true);
-      }
-
-      x_counter++;
-
-      if ((i + 1) % 16 == 0) {
-        x_counter = 0;
-        y_counter++;
-      } else if ((i + 1) % 256 == 0) {
-        y_counter = 0;
-      }
-    }
-  }
 }

--- a/src/game/level.cpp
+++ b/src/game/level.cpp
@@ -94,7 +94,7 @@ void Level::load_json(std::vector<std::shared_ptr<Entity>>* entities, const std:
 	}
 }
 
-void Level::init() {
+void Level::level_init() {
 	for (const BackgroundJSON arr : background) {
 		u32 x = arr.x;
 		u32 y = arr.y;

--- a/src/game/level.cpp
+++ b/src/game/level.cpp
@@ -2,210 +2,193 @@
 
 #include <engine/input/asset.h>
 
+void Level::load_json(std::vector<std::shared_ptr<Entity>> *entities, const std::string path) {
+  char real_path[256];
 
-void Level::load_json(std::vector<std::shared_ptr<Entity>>* entities, const std::string path) {
-	char real_path[256];
+  asset_find(path.c_str(), real_path);
 
-	asset_find(path.c_str(), real_path);
+  simdjson::padded_string json = simdjson::padded_string::load(real_path);
 
-	simdjson::padded_string json = simdjson::padded_string::load(real_path);
+  this->json_data = this->json_parser.iterate(json);
 
-	this->json_data = this->json_parser.iterate(json);
+  simdjson::ondemand::object json_data_obj(this->json_data.get_object());
+  u32 json_data_size = json_data_obj.count_fields();
+  std::string layer_id;
 
-	simdjson::ondemand::object json_data_obj(this->json_data.get_object());
-	u32 json_data_size = json_data_obj.count_fields();
-	std::string layer_id;
+  for (u32 i = 0; i < (json_data_size - 14); i++) {
+    if (i == 0)
+      layer_id = "/layers";
+    else
+      layer_id = "/layers" + std::to_string(i);
 
-	for (u32 i = 0; i < (json_data_size - 14); i++) {
-		if (i == 0)
-			layer_id = "/layers";
-		else
-			layer_id = "/layers" + std::to_string(i);
+    simdjson::ondemand::array layers = this->json_data.at_pointer(layer_id).get_array();
 
-		simdjson::ondemand::array layers = this->json_data.at_pointer(layer_id).get_array();
+    simdjson::ondemand::array background_array = layers.at_pointer("/0/chunks").get_array();
 
-		simdjson::ondemand::array background_array = layers.at_pointer("/0/chunks").get_array();
+    u32 bg_array_size = background_array.count_elements();
 
-		u32 bg_array_size = background_array.count_elements();
+    for (u32 i = 0; i < bg_array_size; i++) {
+      std::string json_pointer = layer_id + "/0/chunks/" + std::to_string(i);
 
-		for (u32 i = 0; i < bg_array_size; i++) {
+      simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
 
-			std::string json_pointer = layer_id + "/0/chunks/" + std::to_string(i);
+      f64 x = obj["x"];
+      f64 y = obj["y"];
 
-			simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
+      std::vector<u32> values;
 
-			double x = obj["x"];
-			double y = obj["y"];
+      simdjson::ondemand::array arr((obj["data"].get_array()));
 
-			std::vector<u32> values;
+      for (f64 value : arr)
+        values.push_back(value);
 
-			simdjson::ondemand::array arr((obj["data"].get_array()));
+      this->background_content.emplace_back(x, y, std::move(values));
+    }
 
-			for (double value : arr)
-				values.push_back(value);
+    simdjson::ondemand::array objects_array = this->json_data.at_pointer(layer_id + "/1/objects").get_array();
+    u32 obj_array_size                      = objects_array.count_elements();
 
+    for (u32 i = 0; i < obj_array_size; i++) {
+      std::string json_pointer = layer_id + "/1/objects/" + std::to_string(i);
 
-			this->background_content.emplace_back(x, y, std::move(values));
-		}
+      simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
 
-		simdjson::ondemand::array objects_array = this->json_data.at_pointer(layer_id + "/1/objects").get_array();
-		u32 obj_array_size = objects_array.count_elements();
+      f64 x          = obj["x"];
+      f64 y          = obj["y"];
+      f64 width      = obj["width"];
+      f64 height     = obj["height"];
+      f64 tileset_id = obj["id"];
 
-		for (u32 i = 0; i < obj_array_size; i++) {
+      simdjson::ondemand::array property_array = this->json_data.at_pointer(json_pointer + "/properties").get_array();
+      u32 prop_array_size                      = property_array.count_elements();
+      std::string script                       = "return";
 
-			std::string json_pointer = layer_id + "/1/objects/" + std::to_string(i);
+      for (u32 i = 0; i < prop_array_size; i++) {
+        simdjson::ondemand::object obj(property_array.at_pointer("/" + std::to_string(i)).get_object());
 
-			simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
+        script = std::string_view(obj["value"]);
+      }
 
-			double x = obj["x"];
-			double y = obj["y"];
-			double width = obj["width"];
-			double height = obj["height"];
-			double tileset_id = obj["id"];
+      objects_content.emplace_back(x, y, width, height, tileset_id, script);
+    }
 
-			simdjson::ondemand::array property_array = this->json_data.at_pointer(json_pointer + "/properties").get_array();
-			u32 prop_array_size = property_array.count_elements();
-			std::string_view script = "0";
+    simdjson::ondemand::array collisions_array = this->json_data.at_pointer(layer_id + "/2/chunks").get_array();
 
-			for (u32 i = 0; i < prop_array_size; i++) {
+    u32 co_array_size = collisions_array.count_elements();
 
-				simdjson::ondemand::object obj(property_array.at_pointer("/" + std::to_string(i)).get_object());
+    for (u32 i = 0; i < co_array_size; i++) {
+      std::string json_pointer = layer_id + "/2/chunks/" + std::to_string(i);
 
-				script = obj["value"];
-			}
+      simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
 
-			objects_content.emplace_back(x, y, width, height, tileset_id, script);
-		}
+      i64 x = obj["x"];
+      i64 y = obj["y"];
 
-		simdjson::ondemand::array collisions_array = this->json_data.at_pointer(layer_id + "/2/chunks").get_array();
+      std::vector<u64> values;
 
-		u32 co_array_size = collisions_array.count_elements();
+      simdjson::ondemand::array arr((obj["data"].get_array()));
 
-		for (u32 i = 0; i < co_array_size; i++) {
+      for (u64 value : arr)
+        values.push_back(value);
 
-			std::string json_pointer = layer_id + "/2/chunks/" + std::to_string(i);
+      collisions_content.emplace_back(x, y, std::move(values));
+    }
+  }
 
-			simdjson::ondemand::object obj(this->json_data.at_pointer(json_pointer).get_object());
+  simdjson::ondemand::array tilesets = this->json_data["tilesets"];
+  u32 tilesets_size                  = tilesets.count_elements();
 
-			double x = obj["x"];
-			double y = obj["y"];
+  for (int i = 0; i < tilesets_size; i++) {
+    std::string json_pointer = "/tilesets/" + std::to_string(i);
+    std::string_view tileset_id;
 
-			std::vector<double> values;
+    simdjson::ondemand::object obj(json_data.at_pointer(json_pointer).get_object());
+    std::string_view tileset = obj["source"];
 
-			simdjson::ondemand::array arr((obj["data"].get_array()));
+    tileset_id_jsons.emplace_back(tileset);
+  }
 
-			for (double value : arr)
-				values.push_back(value);
+  for (u32 i = 0; i < tileset_id_jsons.size(); i++)
+    std::cout << tileset_id_jsons[i] << std::endl;
 
-			collisions_content.emplace_back(x, y, std::move(values));
-		}
-	}
+  for (u32 i = 0; i < tileset_id_jsons.size(); i++) {
+    std::string tileset             = tileset_id_jsons.at(i);
+    simdjson::padded_string id_json = simdjson::padded_string::load(tileset);
 
-	simdjson::ondemand::array tilesets = this->json_data["tilesets"];
-	u32 tilesets_size = tilesets.count_elements();
+    this->id_json_data = json_parser.iterate(id_json);
 
+    simdjson::ondemand::object id_obj = id_json_data;
+    std::string_view tileset_id       = id_obj["image"];
 
-	for (int i = 0; i < tilesets_size; i++) {
-
-		std::string json_pointer = "/tilesets/" + std::to_string(i);
-		std::string_view tileset_id;
-
-		simdjson::ondemand::object obj(json_data.at_pointer(json_pointer).get_object());
-		std::string_view tileset = obj["source"];
-
-
-
-		tileset_id_jsons.emplace_back(tileset);
-	}
-
-	for (u32 i = 0; i < tileset_id_jsons.size(); i++) {
-		std::cout << tileset_id_jsons[i] << std::endl;
-	}
-
-
-	for (u32 i = 0; i < tileset_id_jsons.size(); i++) {
-		std::string tileset = tileset_id_jsons.at(i);
-		simdjson::padded_string id_json = simdjson::padded_string::load(tileset);
-
-		this->id_json_data = json_parser.iterate(id_json);
-
-		simdjson::ondemand::object id_obj = id_json_data;
-		std::string_view tileset_id = id_obj["image"];
-
-		tileset_id_list.emplace_back(tileset_id);
-	}
+    tileset_id_list.emplace_back(tileset_id);
+  }
 }
 
 void Level::update() {
-	for (const auto& arr : background_content) {
-		u32 x_counter = 0;
-		u32 y_counter = 0;
+  for (const auto &arr : background_content) {
+    u32 x_counter = 0;
+    u32 y_counter = 0;
 
-		u32 x = arr.x;
-		u32 y = arr.y;
+    u32 x = arr.x;
+    u32 y = arr.y;
 
-		for (u32 i = 0; i < arr.background_data.size(); i++) {
+    for (u32 i = 0; i < arr.background_data.size(); i++) {
+      u32 data = arr.background_data.at(i);
 
-			u32 data = arr.background_data.at(i);
+      if (data > 0) {
+        std::string id              = tileset_id_list.at(data - 1);
+        std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
+        ent->set_ent_class(EntClass::BACKGROUND);
+        ent->set_texture_path(id);
+        ent->set_pos(vector_make3(x * 0.1 + x_counter * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
+        ent->set_active(true);
+      }
+      x_counter++;
 
-			if (data > 0) {
-				std::string id = tileset_id_list.at(data - 1);
-				std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
-				ent->set_ent_class(EntClass::BACKGROUND);
-				ent->set_texture_path(id);
-				ent->set_pos(vector_make3(x * 0.1 + x_counter * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
-				ent->set_active(true);
-			}
-			x_counter++;
+      if ((i + 1) % 16 == 0) {
+        x_counter = 0;
+        y_counter++;
+      } else if ((i + 1) % 256 == 0) {
+        y_counter = 0;
+      }
+    }
+  }
 
-			if ((i + 1) % 16 == 0) {
-				x_counter = 0;
-				y_counter++;
-			}
-			else if ((i + 1) % 256 == 0) {
-				y_counter = 0;
-			}
-		}
-	}
+  for (const auto &arr : objects_content) {
+    u32 x              = arr.x;
+    u32 y              = arr.y;
+    u32 height         = arr.height;
+    u32 width          = arr.width;
+    u32 id             = arr.tileset_id;
+    std::string script = arr.script;
+  }
 
+  for (const auto &arr : collisions_content) {
+    u32 x_counter = 0;
+    u32 y_counter = 0;
 
-	for (const auto& arr : objects_content) {
-		u32 x = arr.x;
-		u32 y = arr.y;
-		u32 height = arr.height;
-		u32 width = arr.width;
-		u32 id = arr.tileset_id;
-		std::string script = arr.script;
+    for (u32 i = 0; i < arr.collisions_data.size(); i++) {
+      u32 x    = arr.x;
+      u32 y    = arr.y;
+      u32 data = arr.collisions_data.at(i);
 
-	}
+      if (data > 0) {
+        std::string id              = tileset_id_list.at(data - 1);
+        std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
+        ent->set_ent_class(EntClass::BACKGROUND);
+        ent->set_texture_path(id);
+        ent->set_pos(vector_make3(x * 0.1 + x_counter * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
+        ent->set_active(true);
+      }
 
-	for (const auto& arr : collisions_content) {
-		u32 x_counter = 0;
-		u32 y_counter = 0;
+      x_counter++;
 
-		for (u32 i = 0; i < arr.collisions_data.size(); i++) {
-			u32 x = arr.x;
-			u32 y = arr.y;
-			u32 data = arr.collisions_data.at(i);
-
-			if (data > 0) {
-				std::string id = tileset_id_list.at(data - 1);
-				std::shared_ptr<Entity> ent = this->ent_manager->ent_create();
-				ent->set_ent_class(EntClass::BACKGROUND);
-				ent->set_texture_path(id);
-				ent->set_pos(vector_make3(x * 0.1 + x_counter * 0.1, y * 0.1 + y_counter * 0.1, 0.0f));
-				ent->set_active(true);
-			}
-
-			x_counter++;
-
-			if ((i + 1) % 16 == 0) {
-				x_counter = 0;
-				y_counter++;
-			}
-			else if ((i + 1) % 256 == 0) {
-				y_counter = 0;
-			}
-		}
-	}
+      if ((i + 1) % 16 == 0) {
+        x_counter = 0;
+        y_counter++;
+      } else if ((i + 1) % 256 == 0) {
+        y_counter = 0;
+      }
+    }
+  }
 }

--- a/src/game/level.h
+++ b/src/game/level.h
@@ -23,7 +23,6 @@ struct BackgroundJSON {
 		background_data(_background_data), x{ _x }, y{ _y } {}
 };
 
-std::vector<BackgroundJSON> background;
 
 struct ObjectJSON {
 	std::string script;
@@ -37,7 +36,6 @@ struct ObjectJSON {
 		script{ _script }, x{ _x }, y{ _y }, width{ _width }, height{ _height }, tileset_id{ _tile_set_id }  {}
 };
 
-std::vector<ObjectJSON> objects;
 
 struct CollisionJSON {
 	std::vector<i64> collision_data;
@@ -50,13 +48,17 @@ struct CollisionJSON {
 		collision_data(_background_data), x{ _x }, y{ _y } {}
 };
 
-std::vector<CollisionJSON> collisions;
 
-std::vector<std::string> tileset_id_json;
-std::vector<std::string> tileset_id_list;
 
 class Level {
 private:
+	std::vector<BackgroundJSON> background;
+	std::vector<ObjectJSON> objects;
+	std::vector<CollisionJSON> collisions;
+
+	std::vector<std::string> tileset_id_json;
+	std::vector<std::string> tileset_id_list;
+
 	lua_State* lua;
 	EntityManager* ent_manager;
 	simdjson::ondemand::parser json_parser;
@@ -81,7 +83,7 @@ public:
 	};
 
 	void load_json(std::vector<std::shared_ptr<Entity>>* entities, const std::string path);
-	void init();
+	void level_init();
 	void update();
 };
 

--- a/src/game/level.h
+++ b/src/game/level.h
@@ -4,7 +4,6 @@
 #include "entities/entity.h"
 #include "entities/entity_manager.h"
 
-
 #include <engine/input/input.h>
 #include <engine/platform.h>
 #include <engine/render/renderable.h>
@@ -17,39 +16,30 @@
 #include <vector>
 
 struct Background {
-    INT64 x;
-    INT64 y;
-    std::vector<u32> background_data;
-    Background(u32 _x, u32 _y,
-        std::vector<u32>&& _background_data) :
-        x{ _x }, y{ _y }, background_data(_background_data) {}
+  i64 x;
+  i64 y;
+  std::vector<u32> background_data;
 };
 
 struct Objects {
-    INT64 x;
-    INT64 y;
-    u32 width;
-    u32 height;
-    u32 tileset_id;
-    std::string script;
-
-    Objects(u32 _x, u32 _y, u32 _width, u32 _height, u32 _tile_set_id, std::string_view _script) :
-        x{ _x }, y{ _y }, width{ _width }, height{ _height }, tileset_id{ _tile_set_id }, script{ _script } {}
+  i64 x;
+  i64 y;
+  u32 width;
+  u32 height;
+  u32 tileset_id;
+  std::string script;
 };
 
 struct Collisions {
-    INT64 x;
-    INT64 y;
-    std::vector<u32> collisions_data;
-    Collisions(u32 _x, u32 _y,
-        std::vector<u32>&& _background_data) :
-        x{ _x }, y{ _y }, collisions_data(_background_data) {}
+  i64 x;
+  i64 y;
+  std::vector<u64> collisions_data;
 };
 
 class Level {
 private:
   lua_State *lua;
-  EntityManager* ent_manager;
+  EntityManager *ent_manager;
   simdjson::ondemand::parser json_parser;
   simdjson::ondemand::document json_data, id_json_data;
 
@@ -64,18 +54,13 @@ public:
 
   std::vector<std::shared_ptr<Entity>> *get_entities();
 
-  std::vector<struct Background> get_background() {
-      return background_content;
-  };
-  std::vector<struct Objects> get_objects() {
-      return objects_content;
-  };
-  std::vector<struct Collisions> get_collisions() {
-      return collisions_content;
-  };
-  std::vector<std::string> get_tileset_id_list() {
-      return tileset_id_list;
-  };
+  std::vector<Background> get_background() { return background_content; };
+
+  std::vector<Objects> get_objects() { return objects_content; };
+
+  std::vector<Collisions> get_collisions() { return collisions_content; };
+
+  std::vector<std::string> get_tileset_id_list() { return tileset_id_list; };
 
   void load_json(std::vector<std::shared_ptr<Entity>> *entities, const std::string path);
   void update();

--- a/src/game/level.h
+++ b/src/game/level.h
@@ -15,26 +15,45 @@
 #include <string>
 #include <vector>
 
-struct Background {
-	std::vector<u32> background_data;
-	f32 x;
-	f32 y;
+struct BackgroundJSON {
+	std::vector<i64> background_data;
+	double x;
+	double y;
+	BackgroundJSON(std::vector<i64>&& _background_data, double _x, double _y) :
+		background_data(_background_data), x{ _x }, y{ _y } {}
 };
 
-struct Object {
+std::vector<BackgroundJSON> background;
+
+struct ObjectJSON {
 	std::string script;
-	f32 x;
-	f32 y;
-	u32 width;
-	u32 height;
-	u32 tileset_id;
+	double x;
+	double y;
+	int64_t width;
+	int64_t height;
+	int64_t tileset_id;
+
+	ObjectJSON(std::string_view _script, double _x, double _y, int64_t _width, int64_t _height, int64_t _tile_set_id) :
+		script{ _script }, x{ _x }, y{ _y }, width{ _width }, height{ _height }, tileset_id{ _tile_set_id }  {}
 };
 
-struct Collision {
-	std::vector<u32> collisions_data;
-	f32 x;
-	f32 y;
+std::vector<ObjectJSON> objects;
+
+struct CollisionJSON {
+	std::vector<i64> collision_data;
+
+	/* Has to be either double or i64, simdjson doesn't allow other outputs that would be usable here. */
+	double x;
+	double y;
+
+	CollisionJSON(std::vector<i64>&& _background_data, double _x, double _y) :
+		collision_data(_background_data), x{ _x }, y{ _y } {}
 };
+
+std::vector<CollisionJSON> collisions;
+
+std::vector<std::string> tileset_id_json;
+std::vector<std::string> tileset_id_list;
 
 class Level {
 private:
@@ -43,24 +62,18 @@ private:
 	simdjson::ondemand::parser json_parser;
 	simdjson::ondemand::document json_data, id_json_data;
 
-	std::vector<Background> background;
-	std::vector<Object> objects;
-	std::vector<Collision> collisions;
-	std::vector<std::string> tileset_id_json;
-	std::vector<std::string> tileset_id_list;
-
 public:
 	Level(lua_State* lua) { this->lua = lua; }
 
 	std::vector<std::shared_ptr<Entity>>* get_entities();
 
-	std::vector<struct Background> get_background() {
+	std::vector<struct BackgroundJSON> get_background() {
 		return background;
 	};
-	std::vector<struct Object> get_objects() {
+	std::vector<struct ObjectJSON> get_objects() {
 		return objects;
 	};
-	std::vector<struct Collision> get_collisions() {
+	std::vector<struct CollisionJSON> get_collisions() {
 		return collisions;
 	};
 	std::vector<std::string> get_tileset_id_list() {

--- a/src/game/level.h
+++ b/src/game/level.h
@@ -16,54 +16,60 @@
 #include <vector>
 
 struct Background {
-  i64 x;
-  i64 y;
-  std::vector<u32> background_data;
+	std::vector<u32> background_data;
+	f32 x;
+	f32 y;
 };
 
-struct Objects {
-  i64 x;
-  i64 y;
-  u32 width;
-  u32 height;
-  u32 tileset_id;
-  std::string script;
+struct Object {
+	std::string script;
+	f32 x;
+	f32 y;
+	u32 width;
+	u32 height;
+	u32 tileset_id;
 };
 
-struct Collisions {
-  i64 x;
-  i64 y;
-  std::vector<u64> collisions_data;
+struct Collision {
+	std::vector<u32> collisions_data;
+	f32 x;
+	f32 y;
 };
 
 class Level {
 private:
-  lua_State *lua;
-  EntityManager *ent_manager;
-  simdjson::ondemand::parser json_parser;
-  simdjson::ondemand::document json_data, id_json_data;
+	lua_State* lua;
+	EntityManager* ent_manager;
+	simdjson::ondemand::parser json_parser;
+	simdjson::ondemand::document json_data, id_json_data;
 
-  std::vector<Background> background_content;
-  std::vector<Objects> objects_content;
-  std::vector<Collisions> collisions_content;
-  std::vector<std::string> tileset_id_jsons;
-  std::vector<std::string> tileset_id_list;
+	std::vector<Background> background;
+	std::vector<Object> objects;
+	std::vector<Collision> collisions;
+	std::vector<std::string> tileset_id_json;
+	std::vector<std::string> tileset_id_list;
 
 public:
-  Level(lua_State *lua) { this->lua = lua; }
+	Level(lua_State* lua) { this->lua = lua; }
 
-  std::vector<std::shared_ptr<Entity>> *get_entities();
+	std::vector<std::shared_ptr<Entity>>* get_entities();
 
-  std::vector<Background> get_background() { return background_content; };
+	std::vector<struct Background> get_background() {
+		return background;
+	};
+	std::vector<struct Object> get_objects() {
+		return objects;
+	};
+	std::vector<struct Collision> get_collisions() {
+		return collisions;
+	};
+	std::vector<std::string> get_tileset_id_list() {
+		return tileset_id_list;
+	};
 
-  std::vector<Objects> get_objects() { return objects_content; };
-
-  std::vector<Collisions> get_collisions() { return collisions_content; };
-
-  std::vector<std::string> get_tileset_id_list() { return tileset_id_list; };
-
-  void load_json(std::vector<std::shared_ptr<Entity>> *entities, const std::string path);
-  void update();
+	void load_json(std::vector<std::shared_ptr<Entity>>* entities, const std::string path);
+	void init();
+	void update();
 };
 
 #endif

--- a/src/game/level.h
+++ b/src/game/level.h
@@ -2,6 +2,8 @@
 #define __GAME_LEVEL_H
 
 #include "entities/entity.h"
+#include "entities/entity_manager.h"
+
 
 #include <engine/input/input.h>
 #include <engine/platform.h>
@@ -14,16 +16,66 @@
 #include <string>
 #include <vector>
 
+struct Background {
+    INT64 x;
+    INT64 y;
+    std::vector<u32> background_data;
+    Background(u32 _x, u32 _y,
+        std::vector<u32>&& _background_data) :
+        x{ _x }, y{ _y }, background_data(_background_data) {}
+};
+
+struct Objects {
+    INT64 x;
+    INT64 y;
+    u32 width;
+    u32 height;
+    u32 tileset_id;
+    std::string script;
+
+    Objects(u32 _x, u32 _y, u32 _width, u32 _height, u32 _tile_set_id, std::string_view _script) :
+        x{ _x }, y{ _y }, width{ _width }, height{ _height }, tileset_id{ _tile_set_id }, script{ _script } {}
+};
+
+struct Collisions {
+    INT64 x;
+    INT64 y;
+    std::vector<u32> collisions_data;
+    Collisions(u32 _x, u32 _y,
+        std::vector<u32>&& _background_data) :
+        x{ _x }, y{ _y }, collisions_data(_background_data) {}
+};
+
 class Level {
 private:
   lua_State *lua;
+  EntityManager* ent_manager;
   simdjson::ondemand::parser json_parser;
-  simdjson::ondemand::document json_data;
+  simdjson::ondemand::document json_data, id_json_data;
+
+  std::vector<Background> background_content;
+  std::vector<Objects> objects_content;
+  std::vector<Collisions> collisions_content;
+  std::vector<std::string> tileset_id_jsons;
+  std::vector<std::string> tileset_id_list;
 
 public:
   Level(lua_State *lua) { this->lua = lua; }
 
   std::vector<std::shared_ptr<Entity>> *get_entities();
+
+  std::vector<struct Background> get_background() {
+      return background_content;
+  };
+  std::vector<struct Objects> get_objects() {
+      return objects_content;
+  };
+  std::vector<struct Collisions> get_collisions() {
+      return collisions_content;
+  };
+  std::vector<std::string> get_tileset_id_list() {
+      return tileset_id_list;
+  };
 
   void load_json(std::vector<std::shared_ptr<Entity>> *entities, const std::string path);
   void update();


### PR DESCRIPTION
SimdJSON implementation, mostly done with at_pointers to the required objects or arrays. To make sure the code works any numbers of objects, layers, and arrays, the elements in question are always counted before any reading occurs. All required data is stored in structs, which are then loaded on a vector from which all data is accessible later.  Iterating through different layers is achieved by counting all members of the JSON-file and subtracting the members which aren't layers from the total (14 atm). If any other things except layers are added to a JSON, this needs to be changed.
The update method uses said data to create entities when required. I wasn't sure how to implement this for objects, so this part is yet to be done.  The EntClass for collisions is "Background" atm, not sure if this is correct.
There shouldn't be any bugs or errors while interating through the JSON, there may be some in the update method.
Wrote INT64 instead of i64 because I'm not familiar with these naming system, so I may have also labeled some variables with an unfitting prefix.